### PR TITLE
Safari scrolling bug.

### DIFF
--- a/dist/js/components/modal.js
+++ b/dist/js/components/modal.js
@@ -65,7 +65,6 @@ var Modal = function (_Utils) {
     // bind events to class
     _this.getModal = _this.getModal.bind(_this);
     _this.handleModalClose = _this.handleModalClose.bind(_this);
-    _this.getOffsetValue = _this.getOffsetValue.bind(_this);
     _this.handleEscapeKeyPress = _this.handleEscapeKeyPress.bind(_this);
     _this.handleOverlayClick = _this.handleOverlayClick.bind(_this);
     return _this;
@@ -157,7 +156,6 @@ var Modal = function (_Utils) {
       this.modalCloseButtons = this.findElements(this.modalOverlayAttr + " " + this.closeButtonAttr);
 
       this.handleScrollStop();
-      this.getOffsetValue(this.modalOverlay);
       this.captureFocus(this.activeModalSelector);
       this.modalOverlay.setAttribute(selectors.MODAL_VISIBLE, "");
       this.modalOverlay.setAttribute("aria-hidden", "false");
@@ -168,7 +166,6 @@ var Modal = function (_Utils) {
       this.modalOverlay.scrollTop = 0;
 
       // begin listening to events
-      window.addEventListener(events.RESIZE, this.getOffsetValue);
       document.addEventListener(events.KEYDOWN, this.handleEscapeKeyPress);
       document.addEventListener(events.CLICK, this.handleOverlayClick);
       this.modalCloseButtons.forEach(function (button) {
@@ -196,7 +193,6 @@ var Modal = function (_Utils) {
       this.handleScrollRestore();
 
       // stop listening to events
-      window.removeEventListener(events.RESIZE, this.getOffsetValue);
       document.removeEventListener(events.KEYDOWN, this.handleEscapeKeyPress);
       document.removeEventListener(events.CLICK, this.handleOverlayClick);
       this.modalCloseButtons.forEach(function (button) {
@@ -244,19 +240,6 @@ var Modal = function (_Utils) {
       this.modalButton.setAttribute("tabindex", "-1");
       this.modalButton.focus();
       this.modalButton.removeAttribute("tabindex");
-    }
-
-    /**
-     * Finds the pixel value to offset the modal by to keep it in the current scroll area.
-     * @param {Object} container - Currently active modal.
-     * @return {null}
-     */
-
-  }, {
-    key: "getOffsetValue",
-    value: function getOffsetValue() {
-      var scrollPosition = Math.round(document.body.scrollTop || window.pageYOffset);
-      this.modalOverlay.style.top = scrollPosition + "px";
     }
 
     /**

--- a/framework/js/components/modal.js
+++ b/framework/js/components/modal.js
@@ -45,7 +45,6 @@ export default class Modal extends Utils {
     // bind events to class
     this.getModal = this.getModal.bind(this)
     this.handleModalClose = this.handleModalClose.bind(this)
-    this.getOffsetValue = this.getOffsetValue.bind(this)
     this.handleEscapeKeyPress = this.handleEscapeKeyPress.bind(this)
     this.handleOverlayClick = this.handleOverlayClick.bind(this)
   }
@@ -117,7 +116,6 @@ export default class Modal extends Utils {
     this.modalCloseButtons = this.findElements(`${this.modalOverlayAttr} ${this.closeButtonAttr}`)
 
     this.handleScrollStop()
-    this.getOffsetValue(this.modalOverlay)
     this.captureFocus(this.activeModalSelector)
     this.modalOverlay.setAttribute(selectors.MODAL_VISIBLE, "")
     this.modalOverlay.setAttribute("aria-hidden", "false")
@@ -128,7 +126,6 @@ export default class Modal extends Utils {
     this.modalOverlay.scrollTop = 0
 
     // begin listening to events
-    window.addEventListener(events.RESIZE, this.getOffsetValue)
     document.addEventListener(events.KEYDOWN, this.handleEscapeKeyPress)
     document.addEventListener(events.CLICK, this.handleOverlayClick)
     this.modalCloseButtons.forEach(button => {
@@ -151,7 +148,6 @@ export default class Modal extends Utils {
     this.handleScrollRestore()
 
     // stop listening to events
-    window.removeEventListener(events.RESIZE, this.getOffsetValue)
     document.removeEventListener(events.KEYDOWN, this.handleEscapeKeyPress)
     document.removeEventListener(events.CLICK, this.handleOverlayClick)
     this.modalCloseButtons.forEach(button => {
@@ -190,16 +186,6 @@ export default class Modal extends Utils {
     this.modalButton.setAttribute("tabindex", "-1")
     this.modalButton.focus()
     this.modalButton.removeAttribute("tabindex")
-  }
-
-  /**
-   * Finds the pixel value to offset the modal by to keep it in the current scroll area.
-   * @param {Object} container - Currently active modal.
-   * @return {null}
-   */
-  getOffsetValue() {
-    const scrollPosition = Math.round(document.body.scrollTop || window.pageYOffset)
-    this.modalOverlay.style.top = `${scrollPosition}px`
   }
 
   /**

--- a/framework/scss/components/_modal.scss
+++ b/framework/scss/components/_modal.scss
@@ -13,7 +13,7 @@
   overflow-y: auto;
   overflow-x: hidden;
   opacity: 0;
-  position: absolute;
+  position: fixed;
   height: 100%;
   width: 100%;
   top: 0;


### PR DESCRIPTION
Prevents modal overlay from being pushed down. used fixed positioning instead of absolute. No need for offsetting the overlay.